### PR TITLE
Fix cyclic dependency on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,15 @@
-import httpie_httpsig_auth
-
 from setuptools import setup
 
 
 setup(
     name='httpie-httpsig-auth',
     description='HTTP Signatures plugin for HTTPie.',
-    version='0.1.0',
-    author=httpie_httpsig_auth.__author__,
+    version='0.1.1',
+    author="Mike Manuthu",
     author_email='mmanuthu@east36.co.ke',
     url='https://github.com/east36/httpie-http-signatures',
     download_url='https://github.com/east36/httpie-http-signatures',
-    license=httpie_httpsig_auth.__licence__,
+    license="MIT",
     py_modules=['httpie_httpsig_auth'],
     zip_safe=False,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author_email='mmanuthu@east36.co.ke',
     url='https://github.com/east36/httpie-http-signatures',
     download_url='https://github.com/east36/httpie-http-signatures',
-    license="MIT",
+    license="BSD",
     py_modules=['httpie_httpsig_auth'],
     zip_safe=False,
     entry_points={
@@ -29,7 +29,7 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'Environment :: Plugins',
-        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: BSD License',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Utilities',
         'Topic :: System :: Networking',


### PR DESCRIPTION
 import httpie_httpsig_auth in setup.py breaks installations. 
This patch removes it.